### PR TITLE
Fixed a problem with spaces when parsing

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,7 +3,7 @@
   <component name="ProjectKey">
     <option name="state" value="project://e2804f05-5315-4fc6-a121-c522a6c26470" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="9.0" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/team/h/ProblemParser.java
+++ b/src/team/h/ProblemParser.java
@@ -14,7 +14,9 @@ import java.util.stream.Collectors;
 public class ProblemParser {
 
     private String problemFilePath;
+
     private List<Problem> problems = new ArrayList<>();
+
 
     public ProblemParser(String problemFilePath) {
         this.problemFilePath = problemFilePath;
@@ -26,9 +28,9 @@ public class ProblemParser {
             problemStrings = Files.lines(Paths.get(problemFilePath)).collect(Collectors.toList());
             for (String problemString : problemStrings) {
                 int problemIdentifier = getIdentifier(problemString);
-                List<String> problemComponents = Arrays.asList(problemString.split(" # "));
-                Room problemRoom = createRoom(problemComponents.get(0));
-                List<Shape> problemShapes = createShapes(problemComponents.get(1));
+                List<String> problemComponents = Arrays.asList(problemString.split("#"));
+                Room problemRoom = createRoom(problemComponents.get(0).trim());
+                List<Shape> problemShapes = createShapes(problemComponents.get(1).trim());
                 problems.add(new Problem(problemIdentifier, problemRoom, problemShapes));
             }
         } catch (IOException e) {
@@ -66,5 +68,4 @@ public class ProblemParser {
         }
         return shapes;
     }
-
 }


### PR DESCRIPTION
When passing string as arguments we now trim to remove leading and trailing whitespace. This avoids the error when parsing strings to doubles.